### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.release.toml
+++ b/Cargo.release.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maud-pulldown-cmark"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 description = "An adapter between maud and pulldown-cmark"
 
@@ -14,5 +14,5 @@ keywords = ["maud", "markdown", "pulldown-cmark", "adapter"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-pulldown-cmark = "0.0.5"
-maud = "0.8.0"
+pulldown-cmark = "0.0.8"
+maud = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ default = []
 nightly = ["maud_macros"]
 
 [dependencies]
-pulldown-cmark = "0.0.5"
-maud = "0.8.0"
+pulldown-cmark = "0.0.8"
+maud = "0.9.0"
 # Should be a dev-dependency, but they're not supported with features
-maud_macros = { version = "0.8.0", optional = true }
+maud_macros = { version = "0.9.0", optional = true }
 
 [build-dependencies]
-skeptic = "0.4"
+skeptic = "0.6"
 
 [dev-dependencies]
-skeptic = "0.4"
+skeptic = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maud-pulldown-cmark"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 description = "An adapter between maud and pulldown-cmark"
 


### PR DESCRIPTION
To be able to use the Traits exported from Maud they need to be of the same Crate version. I've updated the dependencies so it works again now.
